### PR TITLE
Introduced a new commandline option -f to omit the GFA version check.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+gfalist
+gfalist_*.deb
+libsky.a
+version.h

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ libsky.a: $(SKY_OBJS)
 #	$(AR) rcv $@ $*.o
 #	rm $*.o
 
-gfalist: $(GFALIST_OBJS)
-	$(CC) $(LFLAGS) $+ -o $@ -lsky
+gfalist: $(GFALIST_OBJS) libsky.a
+	$(CC) $(LFLAGS) $+ -o $@ libsky.a
 gfalist.exe: $(CSRC)
 	$(WINCC)  $+ -o $@ 
 gfalist.ttp: $(CSRC)

--- a/gfalist.1
+++ b/gfalist.1
@@ -1,12 +1,12 @@
-.TH gfalist 1 "06 May 2003"
+.TH GFALIST 1 "06 May 2003" "GFA-List"
 .SH NAME
 gfalist - Reads tokenized GFA BASIC version 3.x source files (.GFA) and converts them to human readable ASCII listings (.LST).
 
 .SH SYNOPSIS
 .B gfalist
-\fR[\fB-o lstfile\fR]
+\fR[\fB-o\fR \fIlstfile\fR]
 .RB [ -vcthi ]
-.RI  gfafile 
+.I gfafile 
 
 .SH DESCRIPTION
 Reads an .gfa file as input.  Produces a .lst (ASCII)
@@ -14,23 +14,39 @@ file as output.
 
 .SH OPTIONS
 .TP
-.BI "\-o " file
+.BR \-o " " \fIfile\fR
 Place output in file \c
 .I file\c
 \&. INLINE data will not be saved. 
 .TP
-.BI "\-i "
-Save INLINE data into separate files, named after the pointers, ending .inl.
+.BR \-b
+bug emulation.
 .TP
-.B -h,--help
+.BR \-c
+conversion.
+.TP
+.BR \-f
+force 
+.B gfalist
+to process the input file even when it is not the correct GFA-Basic version.
+.TP
+.BR \-i
+save INLINE data into separate files, named after the pointers, ending .inl.
+.TP
+.BR \-h ", " \-\-help ", " \-V
 makes 
 .B gfalist
 print a short usage information and exit.
 .TP
-.B -v,--verbose
+.BR \-t
+timer.
+.TP
+.BR \-v ", " \-\-verbose
+make 
 .B gfalist
-prints information about its processing on Standard Error.
+print information about its processing to \fIstderr\fR.
 
+.PP
 For detailed help and description of the implemented commands take a 
 look at the README file and manual which comes with the gfalist package. 
 

--- a/sky.c
+++ b/sky.c
@@ -570,7 +570,7 @@ unsigned char *gf4tp_tp(unsigned char *dst, struct gfainf *gi,
 			src += 8;
 			copy64b(u.ull, dcb);
 
-			dcs = dst;
+			dcs = (char *)dst;
 			sprintf(dcs, "%G", u.d);
 			while (*dcs != '\0')
 				switch (*dcs++) {

--- a/sky.h
+++ b/sky.h
@@ -14,6 +14,7 @@
 #define TP_TIME   0x08 /* Measure time */
 #define TP_BUGEM  0x10 /* Emulate bugs */
 #define TP_SAVEINLINE  0x20 /* Save INLINE data into .inl files */
+#define TP_FORCE  0x40 /* do not check for GFA version */
 
 struct gfahdr {
 	unsigned char resvd:7;


### PR DESCRIPTION
It looks like that at least the version 1,2,3 files can already be processed fine.
So I converted the error message into a warning and inform about the -f option.
I had already introduced this option two years ago. Sincs now adegani addressed this in Issue #1, I published this release and integraded it into master.